### PR TITLE
Release 2.1.0

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check_code]
     outputs:
-      upload_url: ${{ steps.create_draft.outputs.upload_url }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
     - uses: actions/checkout@v2
       

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.xdev-software</groupId>
 	<artifactId>vaadin-date-range-picker-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 
 	<name>Vaadin DateRangePicker Root Project</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.xdev-software</groupId>
 	<artifactId>vaadin-date-range-picker-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 
 	<name>Vaadin DateRangePicker Root Project</name>
 

--- a/vaadin-date-range-picker-demo/pom.xml
+++ b/vaadin-date-range-picker-demo/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.xdev-software</groupId>
 	<artifactId>vaadin-date-range-picker-demo</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>Vaadin DateRangePicker Demo</name>

--- a/vaadin-date-range-picker-demo/pom.xml
+++ b/vaadin-date-range-picker-demo/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.xdev-software</groupId>
 	<artifactId>vaadin-date-range-picker-demo</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>Vaadin DateRangePicker Demo</name>

--- a/vaadin-date-range-picker-demo/src/main/java/software/xdev/vaadin/daterange_picker/example/DateRangePickerStyledDemo.java
+++ b/vaadin-date-range-picker-demo/src/main/java/software/xdev/vaadin/daterange_picker/example/DateRangePickerStyledDemo.java
@@ -75,7 +75,7 @@ public class DateRangePickerStyledDemo extends Composite<VerticalLayout>
 		this.dateRangePicker.addValueChangeListener(ev ->
 		{
 			final DateRangeModel<SimpleDateRange> modell = ev.getValue();
-						
+			
 			this.taResult.clear();
 			// @formatter:off
 			this.taResult.setValue(

--- a/vaadin-date-range-picker-demo/src/main/java/software/xdev/vaadin/daterange_picker/example/DateRangePickerStyledDemo.java
+++ b/vaadin-date-range-picker-demo/src/main/java/software/xdev/vaadin/daterange_picker/example/DateRangePickerStyledDemo.java
@@ -75,13 +75,21 @@ public class DateRangePickerStyledDemo extends Composite<VerticalLayout>
 		this.dateRangePicker.addValueChangeListener(ev ->
 		{
 			final DateRangeModel<SimpleDateRange> modell = ev.getValue();
-			
+						
 			this.taResult.clear();
 			// @formatter:off
 			this.taResult.setValue(
 					"DateRange: " + modell.getDateRange().getKey() + "\r\n" +
 					"Start: " + modell.getStart() + "\r\n" +
-					"End: " + modell.getEnd()
+					"End: " + modell.getEnd() + "\r\n" +
+					(ev.getOldValue() != null ?
+						"OldValue-DateRange: " + ev.getOldValue().getDateRange().getKey() + "\r\n" +
+						"OldValue-Start: " + ev.getOldValue().getStart() + "\r\n" +
+						"OldValue-End: " + ev.getOldValue().getEnd()
+						: "OldValue: null")
+					+ "\r\n"
+					+ "IsFromClient: " + ev.isFromClient()
+					
 				);
 			// @formatter:on
 		});

--- a/vaadin-date-range-picker/pom.xml
+++ b/vaadin-date-range-picker/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>vaadin-date-range-picker</artifactId>
 
 	<packaging>jar</packaging>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 
 	<name>DateRangePicker for Vaadin</name>
 	<description>DateRangePicker for Vaadin</description>

--- a/vaadin-date-range-picker/pom.xml
+++ b/vaadin-date-range-picker/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>vaadin-date-range-picker</artifactId>
 
 	<packaging>jar</packaging>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 
 	<name>DateRangePicker for Vaadin</name>
 	<description>DateRangePicker for Vaadin</description>

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/business/DateRangeModel.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/business/DateRangeModel.java
@@ -82,4 +82,69 @@ public class DateRangeModel<D extends DateRange> implements DateRangeActions<D, 
 		this.dateRange = dateRange;
 		return this;
 	}
+
+	@Override
+	public int hashCode()
+	{
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (this.dateRange == null ? 0 : this.dateRange.hashCode());
+		result = prime * result + (this.end == null ? 0 : this.end.hashCode());
+		result = prime * result + (this.start == null ? 0 : this.start.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(final Object obj)
+	{
+		if(this == obj)
+		{
+			return true;
+		}
+		if(obj == null)
+		{
+			return false;
+		}
+		if(this.getClass() != obj.getClass())
+		{
+			return false;
+		}
+		final DateRangeModel<?> other = (DateRangeModel<?>)obj;
+		if(this.dateRange == null)
+		{
+			if(other.dateRange != null)
+			{
+				return false;
+			}
+		}
+		else if(!this.dateRange.equals(other.dateRange))
+		{
+			return false;
+		}
+		if(this.end == null)
+		{
+			if(other.end != null)
+			{
+				return false;
+			}
+		}
+		else if(!this.end.equals(other.end))
+		{
+			return false;
+		}
+		if(this.start == null)
+		{
+			if(other.start != null)
+			{
+				return false;
+			}
+		}
+		else if(!this.start.equals(other.start))
+		{
+			return false;
+		}
+		return true;
+	}
+	
+	
 }

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
@@ -253,8 +253,10 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 		});
 		this.overlay.addValueChangeListener(ev ->
 		{
-			this.updateFromModel();
-			this.fireEvent(new DateRangeValueChangeEvent<>(this));
+			this.model = ev.getSource().getModel();
+			
+			this.updateFromModel(false);
+			this.fireEvent(new DateRangeValueChangeEvent<>(this, ev.getOldValue(), ev.isFromClient()));
 		});
 	}
 	
@@ -263,7 +265,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 	{
 		this.setLocaleFromClient();
 		
-		this.updateFromModel();
+		this.updateFromModel(true);
 		
 		this.addClickOutsideListener();
 	}
@@ -328,9 +330,12 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 		}
 	}
 	
-	public void updateFromModel()
+	public void updateFromModel(final boolean updateOverlay)
 	{
-		this.tryFixInvalidModel();
+		if(updateOverlay)
+		{
+			this.tryFixInvalidModel();
+		}
 		
 		final DateTimeFormatter formatter =
 			DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(this.getFormatLocale());
@@ -346,7 +351,10 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 		);
 		// @formatter:on
 		
-		this.overlay.setModel(this.model);
+		if(updateOverlay)
+		{
+			this.overlay.setModel(this.model);
+		}
 	}
 	
 	protected void tryFixInvalidModel()
@@ -462,7 +470,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 	public DateRangePicker<D> setStart(final LocalDate start)
 	{
 		this.model.setStart(start);
-		this.updateFromModel();
+		this.updateFromModel(true);
 		return this;
 	}
 	
@@ -476,7 +484,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 	public DateRangePicker<D> setEnd(final LocalDate end)
 	{
 		this.model.setEnd(end);
-		this.updateFromModel();
+		this.updateFromModel(true);
 		return this;
 	}
 	
@@ -490,7 +498,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 	public DateRangePicker<D> setDateRange(final D dateRange)
 	{
 		this.model.setDateRange(dateRange);
-		this.updateFromModel();
+		this.updateFromModel(true);
 		return this;
 	}
 	
@@ -498,7 +506,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 	public void setValue(final DateRangeModel<D> value)
 	{
 		this.model = value;
-		this.updateFromModel();
+		this.updateFromModel(true);
 	}
 	
 	@Override

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
@@ -325,7 +325,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 		}
 	}
 	
-	public void updateFromModel(final boolean updateOverlay)
+	protected void updateFromModel(final boolean updateOverlay)
 	{
 		if(updateOverlay)
 		{

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
@@ -282,11 +282,6 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 			return;
 		}
 		
-		/*
-		 * JS-Explanation
-		 * Base Function (see https://stackoverflow.com/a/28432139/13122067)
-		 * If a click was trigger, check if it originated from this element
-		 */
 		final String funcName = "outsideClickFunc" + this.getId().get();
 		
 		// @formatter:off
@@ -310,7 +305,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 			"    spEl.$server.clickOutsideOccured()\r\n" +
 			"  }\r\n" +
 			"}; \r\n" +
-			"document.addEventListener('click'," + funcName + ");";
+			"document.body.addEventListener('click'," + funcName + ");";
 		// @formatter:on
 		
 		this.getContent().getElement().executeJs(jsCommand);

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangeValueChangeEvent.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangeValueChangeEvent.java
@@ -28,30 +28,10 @@ import software.xdev.vaadin.daterange_picker.business.DateRangeModel;
 public class DateRangeValueChangeEvent<D extends DateRange> extends ComponentValueChangeEvent<DateRangePicker<D>, DateRangeModel<D>>
 {
 	public DateRangeValueChangeEvent(
-		DateRangePicker<D> source)
+		final DateRangePicker<D> source,
+		final DateRangeModel<D> oldValue,
+		final boolean isFromClient)
 	{
-		super(source, source, null, false);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * @deprecated Not implemented
-	 */
-	@Deprecated
-	@Override
-	public DateRangeModel<D> getOldValue()
-	{
-		return super.getOldValue();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * @deprecated Not implemented
-	 */
-	@Deprecated
-	@Override
-	public boolean isFromClient()
-	{
-		return super.isFromClient();
+		super(source, source, oldValue, isFromClient);
 	}
 }


### PR DESCRIPTION
## Changelog

* ⚠️ Changed the internal handling of the DateRangeModel/ValueChangeEvent #48
  * Some public method signatures have been slightly changed
  * The DateRangeModel is no longer bound directly
    * It is now explicitly updated by calling setters
    * The returned model is not always the same
* Implement oldValue and isFromClient in ValueChangeEvent #50 
* Overlay closes unexpectedly #47 