### PR TITLE
Feature/#34 allow future selection over start date

### DIFF
--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
@@ -399,6 +399,19 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 		return this.overlayContainer;
 	}
 	
+	// -- SET ALLOW RANGE LIMIT EXCEEDING
+	
+	/**
+	 * Allows the maximum start and end date to be greater or less
+	 * than the configured end or start date.
+	 * 
+	 * @param allowRangeLimitExceeding
+	 */
+	public void setAllowRangeLimitExceeding(final boolean allowRangeLimitExceeding)
+	{
+		this.overlay.setAllowRangeOverlap(allowRangeLimitExceeding);
+	}
+	
 	// -- LABELS --
 	
 	/**

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePicker.java
@@ -409,7 +409,7 @@ public class DateRangePicker<D extends DateRange> extends Composite<VerticalLayo
 	 */
 	public void setAllowRangeLimitExceeding(final boolean allowRangeLimitExceeding)
 	{
-		this.overlay.setAllowRangeOverlap(allowRangeLimitExceeding);
+		this.overlay.setAllowRangeLimitExceeding(allowRangeLimitExceeding);
 	}
 	
 	// -- LABELS --

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePickerOverlay.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePickerOverlay.java
@@ -67,6 +67,8 @@ public class DateRangePickerOverlay<D extends DateRange> extends Composite<Verti
 	protected DateRangePicker<D> dateRangePicker;
 	protected DateRangeModel<D> currentModel;
 	
+	protected boolean allowRangeLimitExceeding = false;
+	
 	/*
 	 * UI-Comp
 	 */
@@ -218,8 +220,11 @@ public class DateRangePickerOverlay<D extends DateRange> extends Composite<Verti
 		this.btnBackwardRange.setEnabled(fastNavEnabled);
 		this.btnForwardRange.setEnabled(fastNavEnabled);
 		
-		this.dpEnd.setMin(model.getStart());
-		this.dpStart.setMax(model.getEnd());
+		if(!this.isAllowRangeOverlap())
+		{
+			this.dpEnd.setMin(model.getStart());
+			this.dpStart.setMax(model.getEnd());
+		}
 		
 		this.cbDateRange.setValue(model.getDateRange());
 		this.dpStart.setValue(model.getStart());
@@ -300,6 +305,16 @@ public class DateRangePickerOverlay<D extends DateRange> extends Composite<Verti
 	public boolean isReadOnly()
 	{
 		return this.readOnly;
+	}
+	
+	public void setAllowRangeLimitExceeding(final boolean allowRangeLimitExceeding)
+	{
+		this.allowRangeLimitExceeding = allowRangeLimitExceeding;
+	}
+	
+	public boolean isAllowRangeLimitExceeding()
+	{
+		return this.allowRangeLimitExceeding;
 	}
 	
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePickerOverlay.java
+++ b/vaadin-date-range-picker/src/main/java/software/xdev/vaadin/daterange_picker/ui/DateRangePickerOverlay.java
@@ -220,7 +220,7 @@ public class DateRangePickerOverlay<D extends DateRange> extends Composite<Verti
 		this.btnBackwardRange.setEnabled(fastNavEnabled);
 		this.btnForwardRange.setEnabled(fastNavEnabled);
 		
-		if(!this.isAllowRangeOverlap())
+		if(!this.isAllowRangeLimitExceeding())
 		{
 			this.dpEnd.setMin(model.getStart());
 			this.dpStart.setMax(model.getEnd());


### PR DESCRIPTION
Fixes #34 
I've create a method setAllowRangeLimitExceeding(boolean) in class DateRangePicker. If you set it to true, start date could be set after end date or end date could be set before start date:
![grafik](https://user-images.githubusercontent.com/86833123/125045043-dea7f000-e09c-11eb-9a6a-da01d179328c.png)
 
if set to false:
![grafik](https://user-images.githubusercontent.com/86833123/125045206-072fea00-e09d-11eb-8755-bff76a926a52.png)
